### PR TITLE
Add ability for user to easily switch AWS Regions/Zones

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ terraform {
 }
 # Configure the AWS Provider
 provider "aws" {
-  region = "us-east-1"
+  region = var.aws_region
 }
 
 resource "random_string" "deployment_id" {

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -26,11 +26,16 @@ resource "aws_vpc" "aap_infrastructure_vpc" {
 #
 # Subnets
 #
+
+# Declare data source for availablity zones
+data "aws_availability_zones" "availability_zone_list" {
+  state = "available"
+}
 resource "aws_subnet" "aap_infrastructure_subnets" {
   count = length(var.infrastructure_vpc_subnets)
   vpc_id = aws_vpc.aap_infrastructure_vpc.id
   cidr_block = var.infrastructure_vpc_subnets[count.index]["cidr_block"]
-  availability_zone = var.infrastructure_vpc_subnets[count.index]["availability_zone"]
+  availability_zone = data.aws_availability_zones.availability_zone_list.names[0]
 
   tags = merge(
     {

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -22,26 +22,21 @@ variable "infrastructure_vpc_subnets" {
   type = list(object({
     name = string
     cidr_block = string
-    availability_zone = string
   }))
   default = [{
     name = "controller"
     cidr_block = "172.16.0.0/24"
-    availability_zone = "us-east-1a"
   },
    {
     name = "execution"
     cidr_block = "172.16.1.0/24"
-    availability_zone = "us-east-1b"
   },
    {
     name = "hub"
     cidr_block = "172.16.2.0/24"
-    availability_zone = "us-east-1c"
   },
   {
     name = "eda"
     cidr_block = "172.16.3.0/24"
-    availability_zone = "us-east-1d"
   }]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,11 @@ output "deployment_id" {
   value = var.deployment_id == "" ? random_string.deployment_id[0].id : var.deployment_id
 }
 
+output "aws_region" {
+  description = "Print AWS Region"
+  value = var.aws_region
+}
+
 output "vpc_module_outputs" {
   description = "VPC outputs"
   value = module.vpc

--- a/variables.tf
+++ b/variables.tf
@@ -7,6 +7,16 @@ variable "deployment_id" {
   }
 }
 
+variable "aws_region" {
+  description = "AWS Region to be used"
+  type = string
+
+  validation {
+  condition = can(regex("[a-z][a-z]-[a-z]+-[1-9]", var.aws_region))
+  error_message = "Must be valid AWS Region names."
+}
+}
+
 # Database variables
 variable "infrastructure_db_allocated_storage" {
   description = "The allocated storage in gibibytes"


### PR DESCRIPTION
This PR removes hardcoded values for AWS Region and Availability Zones,  adds `aws_region` as a variable, and gets availability zone for user provided aws_region from `aws_availability_zones` data source

Jira: https://issues.redhat.com/browse/AAP-19035

Steps to test:
1. Pull down the pr
2. Deploy resources using steps mentioned here https://github.com/ansible-content-lab/aws_terraform_deployment#deploying-infrastructure

Expected output: 
- Resources are deployed in the aws region provided by the user
- Subnets are created in an availability zone of user provided aws region using data source [aws_availability_zones](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones)
Example - if user provided region is `us-east-1`, then resources are deployed in us-east-1 and subnets will be in AZ of us-east-1 (eg - us-east-1a)