### PR TITLE
user can configure one or multiple ec2 instances for Controller and Hub

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -60,10 +60,10 @@ data "aws_ami" "instance_ami" {
 module "controller_vm" {
   source = "./modules/vms"
 
-  count = var.number_of_controller_instances
+  count = var.controller_instances_count
   deployment_id = var.deployment_id
   instance_name_suffix = random_string.instance_name_suffix.result
-  vm_name_prefix = "controller-"
+  vm_name_prefix = "controller-${count.index + 1}-"
   # desired ami id can be specified by replacing below line with `instance_ami = <desired-ami-id-here>`
   instance_ami = data.aws_ami.instance_ami.id
   vpc_security_group_ids = [module.vpc.infrastructure_sg_id]
@@ -73,14 +73,14 @@ module "controller_vm" {
 module "hub_vm" {
   source = "./modules/vms"
 
-  count = var.number_of_hub_instances
+  count = var.hub_instances_count
   deployment_id = var.deployment_id
   instance_name_suffix = random_string.instance_name_suffix.result
-  vm_name_prefix = "hub-"
+  vm_name_prefix = "hub-${count.index + 1}-"
   # desired ami id can be specified by replacing below line with `instance_ami = <desired-ami-id-here>`
   instance_ami = data.aws_ami.instance_ami.id
   vpc_security_group_ids = [module.vpc.infrastructure_sg_id]
-  subnet_id = module.vpc.infrastructure_subnets[0]
+  subnet_id = module.vpc.infrastructure_subnets[2]
 }
 
 module "execution_vm" {

--- a/main.tf
+++ b/main.tf
@@ -60,7 +60,7 @@ data "aws_ami" "instance_ami" {
 module "controller_vm" {
   source = "./modules/vms"
 
-  count = var.controller_instances_count
+  count = var.infrastructure_controller_count
   deployment_id = var.deployment_id
   instance_name_suffix = random_string.instance_name_suffix.result
   vm_name_prefix = "controller-${count.index + 1}-"
@@ -73,7 +73,7 @@ module "controller_vm" {
 module "hub_vm" {
   source = "./modules/vms"
 
-  count = var.hub_instances_count
+  count = var.infrastructure_hub_count
   deployment_id = var.deployment_id
   instance_name_suffix = random_string.instance_name_suffix.result
   vm_name_prefix = "hub-${count.index + 1}-"

--- a/main.tf
+++ b/main.tf
@@ -60,9 +60,23 @@ data "aws_ami" "instance_ami" {
 module "controller_vm" {
   source = "./modules/vms"
 
+  count = var.number_of_controller_instances
   deployment_id = var.deployment_id
   instance_name_suffix = random_string.instance_name_suffix.result
   vm_name_prefix = "controller-"
+  # desired ami id can be specified by replacing below line with `instance_ami = <desired-ami-id-here>`
+  instance_ami = data.aws_ami.instance_ami.id
+  vpc_security_group_ids = [module.vpc.infrastructure_sg_id]
+  subnet_id = module.vpc.infrastructure_subnets[0]
+}
+
+module "hub_vm" {
+  source = "./modules/vms"
+
+  count = var.number_of_hub_instances
+  deployment_id = var.deployment_id
+  instance_name_suffix = random_string.instance_name_suffix.result
+  vm_name_prefix = "hub-"
   # desired ami id can be specified by replacing below line with `instance_ami = <desired-ami-id-here>`
   instance_ami = data.aws_ami.instance_ami.id
   vpc_security_group_ids = [module.vpc.infrastructure_sg_id]

--- a/variables.tf
+++ b/variables.tf
@@ -84,3 +84,16 @@ variable "infrastructure_db_password" {
   sensitive = true
   default = "changeme"
 }
+
+variable "number_of_controller_instances" {
+  description = "The number of ec2 instances for controller"
+  type = number
+  default = 2
+}
+variable "number_of_hub_instances" {
+  description = "The number of ec2 instances for hub"
+  type = number
+  default = 2
+}
+
+

--- a/variables.tf
+++ b/variables.tf
@@ -99,12 +99,12 @@ variable "infrastructure_execution_count" {
   default = 1
 }
 
-variable "controller_instances_count" {
+variable "infrastructure_controller_count" {
   description = "The number of ec2 instances for controller"
   type = number
   default = 1
 }
-variable "hub_instances_count" {
+variable "infrastructure_hub_count" {
   description = "The number of ec2 instances for hub"
   type = number
   default = 1

--- a/variables.tf
+++ b/variables.tf
@@ -98,3 +98,15 @@ variable "infrastructure_execution_count" {
   type = number
   default = 1
 }
+
+variable "number_of_controller_instances" {
+  description = "The number of ec2 instances for controller"
+  type = number
+  default = 2
+}
+variable "number_of_hub_instances" {
+  description = "The number of ec2 instances for hub"
+  type = number
+  default = 2
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -99,14 +99,14 @@ variable "infrastructure_execution_count" {
   default = 1
 }
 
-variable "number_of_controller_instances" {
+variable "controller_instances_count" {
   description = "The number of ec2 instances for controller"
   type = number
-  default = 2
+  default = 1
 }
-variable "number_of_hub_instances" {
+variable "hub_instances_count" {
   description = "The number of ec2 instances for hub"
   type = number
-  default = 2
+  default = 1
 }
 


### PR DESCRIPTION
This PR implements the creation and configuration of one or multiple ec2 instances for controller and hub.

JIRA issue for reference: [https://issues.redhat.com/browse/AAP-18596](https://issues.redhat.com/browse/AAP-18596)

Steps to test:

Pull down the pr
Note the main vars (number of instances) variables for controller and hub added in PR. The number is set to 2 for testing but i can set to 1 prior to merge 
Deploy resources using steps mentioned here [(https://github.com/ansible-content-lab/aws_terraform_deployment#deploying-infrastructure](https://github.com/ansible-content-lab/aws_terraform_deployment#deploying-infrastructure)

