### PR TITLE
AAp-19262 -added code to copy pair and copy ssh keys to controller

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -136,3 +136,17 @@ variable "infrastructure_hub_type" {
   type = string
   default = "m5a.large"
 }
+
+variable "infrastructure_private_key_filepath" {
+  description = "Private ssh key file path."
+  type = string
+  default = "~/.ssh/id_rsa"
+}
+variable "infrastructure_public_key_filepath" {
+  description = "Public ssh key file path."
+  type = string
+  default = "~/.ssh/id_rsa.pub"
+}
+
+
+


### PR DESCRIPTION
This PR implements the configuration of ssh keys to connect to the installer host.

JIRA issue for reference: [https://issues.redhat.com/browse/AAP-19262](https://issues.redhat.com/browse/AAP-19262)

Steps to test:

Pull down the pr

Deploy resources using steps mentioned here [(https://github.com/ansible-content-lab/aws_terraform_deployment#deploying-infrastructure](https://github.com/ansible-content-lab/aws_terraform_deployment#deploying-infrastructure)

ssh into controller and ls -a to see .ssh folder

ls in .ssh folder to see private key